### PR TITLE
changes apiServices interface, add resize listener in index js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,3 +38,10 @@ if (location.pathname === '/index.html' || location.pathname === '/') {
   refs.searchForm.addEventListener('submit', searchFilm);
   refs.searchInput.addEventListener('input', _.debounce(searchFilm, 1000));
 }
+
+
+// Слушатель на изменение окна
+window.addEventListener("resize", _.debounce(() =>
+{
+  if (dataProccessing.isResolutionChanged()) dataProccessing.updResolution().then(data => createCards(data)).catch();
+}, 1000), false);


### PR DESCRIPTION
apiServices interface:
addes functionaliry for changin items number depending on screen resolution (for mobile, tab, desktop)
- deletes wrong code, comments, and console.log();
- added private field resultsPerPage that keeps how many items we get from API. Instead of constant RESULTS_PER_PAGE
- adds public method isResolutionChanged for detecting do we need change data for render
- adds private method defineResultsPerPage() that define resultsPerPage based on window.innerWidth
- adds method private 
defineNewPageNumber() that calculates new appCurrentPage for new resolution
- adds public method updResolution() that gets data for new page in case of changing screen resolution

index.js
- adds listener for screen resize. Ask dataProccessing is it necessary to update data. In case dataProccessing is needed to change output data - calls updResolution()